### PR TITLE
resource_load_dir is given relative to root_dir

### DIFF
--- a/experiment.py
+++ b/experiment.py
@@ -69,6 +69,8 @@ class Experiment(Verbose):
         self._models_dir = self._run_dir + "MODELS/"
         if not self._resource_load_dir:
             self._resource_load_dir = self._models_dir
+        else:
+            self._resource_load_dir = self._root_dir + self._resource_load_dir
         self._print("In _setup_env(), setting up test dir at {}".format(self._run_dir))
         if not os.path.isdir(self._base_dir):
             os.mkdir(self._base_dir)


### PR DESCRIPTION
Now loading models should work. Before this commit if I tried to call:
`bl = Baseline(root_dir="/globi/", resource_load_dir="Baseline/10_07_2019___20_34_27/MODELS")`
then the resource manager would attempt to load from `Baseline/10_07_2019___20_34_27/MODELS` instead of `globi/Baseline/10_07_2019___20_34_27/MODELS`

Signed-off-by: dorimedini <dorimedini@gmail.com>