### PR TITLE
Epoch checkpoints should be specific

### DIFF
--- a/experiment.py
+++ b/experiment.py
@@ -150,16 +150,17 @@ class Experiment(Verbose):
 
 
 class ExperimentWithCheckpoints(Experiment):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, period, **kwargs):
+        """
+        :param period: A list of epoch numbers at which callbacks should
+            be called.
+        """
         super(ExperimentWithCheckpoints, self).__init__(*args, **kwargs)
-        self._add_epoch_checkpoint_callback()
+        self._add_epoch_checkpoint_callback(period)
 
-    def get_epoch_save_period(self):
-        return self._resource_manager.get_epoch_save_period()
-
-    def _add_epoch_checkpoint_callback(self):
+    def _add_epoch_checkpoint_callback(self, period):
         for name in self._model_names:
-            cb = self._resource_manager.get_epoch_save_callback(name)
+            cb = self._resource_manager.get_epoch_save_callback(name, period)
             self._trainers[name].add_checkpoint_callback(cb)
 
     def _get_model_at_epoch(self, model_name, epoch):

--- a/resource_manager.py
+++ b/resource_manager.py
@@ -44,9 +44,9 @@ class ResourceManager(Verbose):
 
     def get_epoch_save_callback(self, model_name):
         filepath_template = self._model_save_dir + self._get_checkpoint_file_template(model_name)
-        return SaveModelAtEpochsCallback(filepath_template=filepath_template,
-                                         period=self.get_epoch_save_period(),
-                                         verbose=self._verbose)
+        return ResourceManager.SaveModelAtEpochsCallback(filepath_template=filepath_template,
+                                                         period=self.get_epoch_save_period(),
+                                                         verbose=self._verbose)
 
     def save_model(self, model, model_name):
         model.save(self._get_model_save_fullpath(model_name),
@@ -113,26 +113,25 @@ class ResourceManager(Verbose):
                 self._print("Saved epoch {} not found at {}".format(epoch, self._get_checkpoint_model_name(model_name, epoch)))
         return epoch_model_map
 
+    class SaveModelAtEpochsCallback(Callback):
+        def __init__(self, filepath_template, period=None, verbose=False):
+            super(SaveModelAtEpochsCallback, self).__init__()
+            self.filepath_template = filepath_template
+            self.period = period if period else []
+            self._printer = Verbose(verbose=verbose)
 
-class SaveModelAtEpochsCallback(Callback):
-    def __init__(self, filepath_template, period=None, verbose=False):
-        super(SaveModelAtEpochsCallback, self).__init__()
-        self.filepath_template = filepath_template
-        self.period = period if period else []
-        self._printer = Verbose(verbose=verbose)
-
-    def on_train_begin(self, logs=None):
-        filepath = self.filepath_template.format(epoch="start", **logs)
-        self.model.save(filepath, overwrite=True)
-        self._printer._print("saved model to {}".format(filepath))
-
-    def on_epoch_end(self, epoch, logs=None):
-        if epoch in self.period:
-            filepath = self.filepath_template.format(epoch=epoch, **logs)
+        def on_train_begin(self, logs=None):
+            filepath = self.filepath_template.format(epoch="start", **logs)
             self.model.save(filepath, overwrite=True)
             self._printer._print("saved model to {}".format(filepath))
 
-    def on_train_end(self, logs=None):
-        filepath = self.filepath_template.format(epoch="end", **logs)
-        self.model.save(filepath, overwrite=True)
-        self._printer._print("saved model to {}".format(filepath))
+        def on_epoch_end(self, epoch, logs=None):
+            if epoch in self.period:
+                filepath = self.filepath_template.format(epoch=epoch, **logs)
+                self.model.save(filepath, overwrite=True)
+                self._printer._print("saved model to {}".format(filepath))
+
+        def on_train_end(self, logs=None):
+            filepath = self.filepath_template.format(epoch="end", **logs)
+            self.model.save(filepath, overwrite=True)
+            self._printer._print("saved model to {}".format(filepath))

--- a/resource_manager.py
+++ b/resource_manager.py
@@ -36,16 +36,13 @@ class ResourceManager(Verbose):
     def _get_checkpoint_file_template(self, model_name):
         return model_name + "_epoch_{epoch}.h5"
 
-    def get_epoch_save_period(self):
-        return [0, 1, 2, 3, 8, 40, 90]
+    def get_checkpoint_epoch_keys(self, period):
+        return ['start'] + period + ['end']
 
-    def get_checkpoint_epoch_keys(self):
-        return ['start'] + self.get_epoch_save_period() + ['end']
-
-    def get_epoch_save_callback(self, model_name):
+    def get_epoch_save_callback(self, model_name, period):
         filepath_template = self._model_save_dir + self._get_checkpoint_file_template(model_name)
         return ResourceManager.SaveModelAtEpochsCallback(filepath_template=filepath_template,
-                                                         period=self.get_epoch_save_period(),
+                                                         period=period,
                                                          verbose=self._verbose)
 
     def save_model(self, model, model_name):
@@ -115,7 +112,7 @@ class ResourceManager(Verbose):
 
     class SaveModelAtEpochsCallback(Callback):
         def __init__(self, filepath_template, period=None, verbose=False):
-            super(SaveModelAtEpochsCallback, self).__init__()
+            super(ResourceManager.SaveModelAtEpochsCallback, self).__init__()
             self.filepath_template = filepath_template
             self.period = period if period else []
             self._printer = Verbose(verbose=verbose)


### PR DESCRIPTION
I'm confused as to why we run into problem #48, maybe it's not a bug, but it would help find the problem if the class that controls the number of epochs also controls the name-suffixes of saved epoch models... the current situation is confusing.

In a nutshell, now the `ResourceManager` gets the `period` requested by the calling Experiment (in my case `Baseline`). Given the period, `ResourceManager` can compute the epoch name suffixes saved.