### PR TITLE
Fixed issue with epoch 0 loading baseline model

### DIFF
--- a/experiment.py
+++ b/experiment.py
@@ -187,13 +187,10 @@ class ExperimentWithCheckpoints(Experiment):
                                                                  epoch=epoch)
 
     class _model_at_epoch_context(Experiment._model_context):
-        def __init__(self, experiment, model_name, epoch=None):
+        def __init__(self, experiment, model_name, epoch):
             Experiment._model_context.__init__(self, experiment=experiment, model_name=model_name)
             self._epoch = epoch
 
         def __enter__(self):
-            if not self._epoch:
-                self._model = self._exp._get_model(self._model_name)
-            else:
-                self._model = self._exp._get_model_at_epoch(self._model_name, self._epoch)
+            self._model = self._exp._get_model_at_epoch(self._model_name, self._epoch)
             return self._model


### PR DESCRIPTION
Fixes issue #48 

Problem was epoch got default value `None`, signifying
we want the baseline model, not an epoch. No real
reason to allow caller not to supply epoch, and if
the epoch is 0 we accidentally fetch baseline..

Fix: remove default param, always load *only* a specific
epoch and not the baseline model

Signed-off-by: dorimedini <dorimedini@gmail.com>