### PR TITLE
Load datasets only on demand

### DIFF
--- a/baseline.py
+++ b/baseline.py
@@ -108,14 +108,14 @@ class Baseline(ExperimentWithCheckpoints):
 
     def _phase1_dataset_robustness(self, dataset_name):
         model_name = Baseline.get_model_name(dataset_name)
-        test_set = self._test_sets[model_name]
+        x_test, y_test = self._trainers[model_name].get_test_data()
         with self.open_model(model_name) as model:
-            clean_results = AnalyzeModel.calc_robustness(test_data=(test_set['x'], test_set['y']),
+            clean_results = AnalyzeModel.calc_robustness(test_data=(x_test, y_test),
                                                          model=model,
                                                          batch_size=Baseline.get_dataset_batch_size(dataset_name))
             try:
                 with self.open_model_at_epoch(model_name, 'start') as start_model:
-                    robustness = [AnalyzeModel.calc_robustness(test_data=(test_set['x'], test_set['y']),
+                    robustness = [AnalyzeModel.calc_robustness(test_data=(x_test, y_test),
                                                                model=model,
                                                                source_weights_model=start_model,
                                                                layer_indices=[i],
@@ -150,16 +150,16 @@ class Baseline(ExperimentWithCheckpoints):
     def _phase2_dataset_robustness_by_epoch(self, model, dataset_name, layer):
         model_name = Baseline.get_model_name(dataset_name)
         checkpoints = self.get_checkpoint_epoch_keys()
-        test_set = self._test_sets[model_name]
+        x_test, y_test = self._trainers[model_name].get_test_data()
         robustness = []
         clean_results = AnalyzeModel.calc_robustness(
-            test_data=(test_set['x'], test_set['y']),
+            test_data=(x_test, y_test),
             model=model,
             batch_size=Baseline.get_dataset_batch_size(dataset_name))
         for epoch in checkpoints:
             try:
                 with self.open_model_at_epoch(model_name, epoch) as checkpoint_model:
-                    robustness += [AnalyzeModel.calc_robustness(test_data=(test_set['x'], test_set['y']),
+                    robustness += [AnalyzeModel.calc_robustness(test_data=(x_test, y_test),
                                                                 model=model,
                                                                 source_weights_model=checkpoint_model,
                                                                 layer_indices=[layer],

--- a/experiment.py
+++ b/experiment.py
@@ -47,7 +47,6 @@ class Experiment(Verbose):
         self._resource_manager = ResourceManager(model_save_dir=self._models_dir,
                                                  model_load_dir=self._resource_load_dir,
                                                  verbose=verbose)
-        self._init_test_data()
 
     def _setup_env(self):
         """
@@ -78,23 +77,11 @@ class Experiment(Verbose):
             os.mkdir(self._models_dir)
         self._print("Test dir setup complete")
 
-    def _init_test_data(self):
-        self._test_sets = {}
-        for model_name in self._model_names:
-            self._test_sets[model_name] = {}
-            x_test, y_test = self._trainers[model_name].get_test_data()
-            self._test_sets[model_name]['x'] = x_test
-            self._test_sets[model_name]['y'] = y_test
-
     def _save_model(self, model, name):
         self._resource_manager.save_model(model=model, model_name=name)
 
     def _load_model(self, model_name):
         return self._resource_manager.load_model(model_name)
-
-    def get_test_data(self, model_name):
-        test_set = self._test_sets[model_name]
-        return test_set['x'], test_set['y']
 
     @staticmethod
     def get_dataset_name(dataset):

--- a/trainer.py
+++ b/trainer.py
@@ -52,21 +52,10 @@ class FCTrainer(Verbose):
     def _load_data_normalized(self):
         self._print("Loading and normalizing data.")
         (x_train, y_train), (x_test, y_test) = self._dataset.load_data()
-        self._print("Before reshape:")
-        self._print("x_train.shape: {}".format(x_train.shape))
-        self._print("x_test.shape: {}".format(x_test.shape))
-        self._print("y_train.shape: {}".format(y_train.shape))
-        self._print("y_test.shape: {}".format(y_test.shape))
-        self._print("x_train[0][0][0] is {}".format(x_train[0][0][0]))
-        self._print("x_train.astype('float32')[0][0][0] is {}".format(x_train.astype('float32')[0][0][0]))
         x_train = x_train.astype('float32') / 255.
         x_test = x_test.astype('float32') / 255.
-        self._print("x_train[0][0][0] is now {}".format(x_train[0][0][0]))
         x_train = x_train.reshape((len(x_train), np.prod(x_train.shape[1:])))
         x_test = x_test.reshape((len(x_test), np.prod(x_test.shape[1:])))
-        self._print("After reshape:")
-        self._print("x_train.shape: {}".format(x_train.shape))
-        self._print("x_test.shape: {}".format(x_test.shape))
         self._shape = (np.prod(x_train.shape[1:]),)
         return (x_train, y_train), (x_test, y_test)
 


### PR DESCRIPTION
Fixes issue #52 , sort of.
I couldn't find a way to load only test data from `keras` datasets, if either @galshachaf or @noamloya have better luck googling it I can make this better.
For now, whenever test data or train data is needed, all data is loaded.

At least it doesn't happen on Trainer construction