### PR TITLE
Add experiment winnery ticker layer intersection

### DIFF
--- a/analyze_model.py
+++ b/analyze_model.py
@@ -1,8 +1,10 @@
 import numpy as np
 import collections
 import matplotlib.pylab as plt
+import matplotlib.pyplot as pyplot
 import seaborn as sns
 import csv
+import os
 
 from keras import backend as K
 from kardashigans.verbose import Verbose
@@ -125,3 +127,20 @@ class AnalyzeModel(object):
         AnalyzeModel.export_results_to_csv(results=results, row_labels=row_labels, col_labels=col_labels,
                                            filename="{}_results.csv".format(heatmap_name),
                                            output_dir=save_results_path)
+
+    @staticmethod
+    def generate_robustness_winnery_correlation_graph(pruned_robustness,
+                                                      unpruned_robustness,
+                                                      winnery_intersection_ratio,
+                                                      output_dir,
+                                                      filename):
+        pyplot.style.use('seaborn-darkgrid')
+        pyplot.figure()
+        palette = pyplot.get_cmap('Set1')
+        pyplot.plot(pruned_robustness, marker='', color=palette(0), linewidth=1, alpha=0.9, label='Robustness (pruned)')
+        pyplot.plot(unpruned_robustness, marker='', color=palette(1), linewidth=1, alpha=0.9, label='Robustness (unpruned)')
+        pyplot.plot(winnery_intersection_ratio, marker='', color=palette(2), linewidth=1, alpha=0.9, label='Winning Ticket Intersection (ratio)')
+        pyplot.legend()
+        pyplot.title("Robustness & Winning Ticket Intersection by Layer", loc='right', fontsize=12, fontweight=0, color='orange')
+        pyplot.xlabel("Layer")
+        pyplot.savefig(os.path.join(output_dir, filename), format='png')

--- a/winnery_intersection.py
+++ b/winnery_intersection.py
@@ -4,6 +4,7 @@ from kardashigans.experiment import Experiment, ExperimentWithCheckpoints
 from kardashigans.trainer import FCTrainer
 from keras.datasets import mnist, cifar10
 import math
+import numpy as np
 
 
 class WinneryIntersection(ExperimentWithCheckpoints):
@@ -51,9 +52,8 @@ class WinneryIntersection(ExperimentWithCheckpoints):
             weights = model.layers[i].get_weights()
             input_weights = weights[0]
             # The winning ticket is the edge set consisting of non-zero weighted edges
-            intersection_size = sum([len([w for w in node_input_weights if w != 0])
-                                     for node_input_weights in input_weights])
-            total_weights = sum([len(node_input_weights) for node_input_weights in input_weights])
+            intersection_size = np.count_nonzero(input_weights)
+            total_weights = input_weights.size
             winnery_intersection_size.append(intersection_size)
             winnery_intersection_ratio.append(float(intersection_size) / float(total_weights))
         return winnery_intersection_size, winnery_intersection_ratio

--- a/winnery_intersection.py
+++ b/winnery_intersection.py
@@ -1,0 +1,80 @@
+from kardashigans.analyze_model import AnalyzeModel
+from kardashigans.baseline import Baseline
+from kardashigans.experiment import Experiment
+from kardashigans.trainer import BaseTrainer
+from keras.datasets import mnist, cifar10
+import math
+import numpy as np
+import pandas as pd
+
+
+class WinneryIntersection(Experiment):
+    """
+    Experiment designed to check correlation between robustness of layer i
+    of some trained model, and the number of non-zero weights in layer i of
+    the winnery lotter ticket.
+    """
+    def __init__(self, prune_threshold, *args, **kwargs):
+        assert not math.isnan(prune_threshold) and prune_threshold >= 0, \
+            "Must init WinneryIntersection with non-negative float value for pruning threshold"
+        self._prune_threshold = prune_threshold
+        mnist_name = WinneryIntersection.get_model_name(Experiment.get_dataset_name(mnist))
+        cifar10_name = WinneryIntersection.get_model_name(Experiment.get_dataset_name(cifar10))
+        super(WinneryIntersection, self).__init__(name='WinneryIntersection',
+                                                  model_names=[mnist_name, cifar10_name],
+                                                  trainers={
+                                                      mnist_name: WinneryIntersection.construct_dataset_trainer(mnist),
+                                                      cifar10_name: WinneryIntersection.construct_dataset_trainer(cifar10)
+                                                  },
+                                                  *args, **kwargs)
+
+    @staticmethod
+    def get_model_name(dataset_name):
+        return Baseline.get_model_name(dataset_name)
+
+    @staticmethod
+    def construct_dataset_trainer(dataset):
+        # Train without pruning built-in, to compare pre-pruned model
+        return Baseline.construct_dataset_trainer(dataset)
+
+    def _get_robustness_list(self, model, trainer, test_data):
+        return [AnalyzeModel.calc_robustness(test_data=test_data,
+                                             model=model,
+                                             layer_indices=[i],
+                                             batch_size=32)
+                for i in trainer.get_weighted_layers_indices()]
+
+    def _get_winnery_intersection_size_and_ratio(self, model, trainer):
+        winnery_intersection_size = []
+        winnery_intersection_ratio = []
+        for i in trainer.get_weighted_layers_indices():
+            weights = model.layers[i].get_weights()
+            input_weights = weights[0]
+            # The winning ticket is the edge set consisting of non-zero weighted edges
+            intersection_size = sum([len([w for w in node_input_weights if w != 0])
+                                     for node_input_weights in input_weights])
+            total_weights = sum([len(node_input_weights) for node_input_weights in input_weights])
+            winnery_intersection_size.append(intersection_size)
+            winnery_intersection_ratio.append(float(intersection_size) / float(total_weights))
+        return winnery_intersection_size, winnery_intersection_ratio
+
+    def go(self):
+        unpruned_robustness = {}
+        pruned_robustness = {}
+        winnery_intersection_size = {}
+        winnery_intersection_ratio = {}
+        for model_name, trainer in self.get_trainer_map().items():
+            test_data = self.get_test_data(model_name)
+            with self.open_model(model_name) as model:
+                unpruned_robustness[model_name] = self._get_robustness_list(model, trainer, test_data)
+                BaseTrainer.prune_trained_model(model, self._prune_threshold)
+                pruned_robustness[model_name] = self._get_robustness_list(model, trainer, test_data)
+                winnery_intersection_size[model_name], winnery_intersection_ratio[model_name] = \
+                    self._get_winnery_intersection_size_and_ratio(model, trainer)
+        for model_name in self.get_trainer_map().keys():
+            AnalyzeModel.generate_robustness_winnery_correlation_graph(pruned_robustness[model_name],
+                                                                       unpruned_robustness[model_name],
+                                                                       winnery_intersection_ratio[model_name],
+                                                                       self._output_dir,
+                                                                       model_name + "_robustness_winnery_correlation")
+        # TODO: Show winnery_intersection_ratio alongside unpruned / pruned robustness


### PR DESCRIPTION
Implements #85, based on PR #87 

Results aren't promising, but they're also fishy. From what I can tell all layers have <0.15 robustness, with layer 0 slightly less robust... the heatmaps we have now for Baseline suggest resetting to epoch 0 should give us ~0.4 at least.

If you could give it a go and see what you think that would help. Paste this in colab if you have a few minutes (models are pre-trained):
```
from winnery_intersection import WinneryIntersection
wi = WinneryIntersection(root_dir='/content/drive/My Drive/globi/',
                         resource_load_dir='WinneryIntersection/models_9.8.2019',
                         prune_threshold=0.07)
wi.go()
```