### PR TITLE
Normalize threshold when pruning

### DIFF
--- a/analyze_model.py
+++ b/analyze_model.py
@@ -28,6 +28,15 @@ class AnalyzeModel(object):
                     initializer_method.run(session=session)
 
     @staticmethod
+    def total_edges(model):
+        edges = 0
+        for layer in model.layers:
+            weights = layer.get_weights()
+            if weights:
+                edges += weights[0].size
+        return edges
+
+    @staticmethod
     def calc_robustness(test_data, model, source_weights_model=None, layer_indices=None, batch_size=32):
         """
         Evaluates the model on test data after re-initializing the layers

--- a/trainer.py
+++ b/trainer.py
@@ -131,11 +131,11 @@ class BaseTrainer(Verbose):
             input_weights = weights[0]  # weights[1] is the list of node biases
             weighted_threshold = threshold * np.linalg.norm(input_weights)
             # The incoming edge weights of node N is incoming_edge_weights[N]
-            new_weights = np.where(np.absolute(input_weights) < weighted_threshold, 0, input_weights)
-            model.layers[i].set_weights([np.array(new_weights), weights[1]])
-            pruned_this_time = new_weights.size - np.count_nonzero(new_weights)
+            pruned_weights = np.where(np.absolute(input_weights) < weighted_threshold, 0, input_weights)
+            model.layers[i].set_weights([np.array(pruned_weights), weights[1]])
+            pruned_this_time = pruned_weights.size - np.count_nonzero(pruned_weights)
             pruned_edges += pruned_this_time
-            percent_this_layer = (pruned_this_time * 100) // new_weights.size
+            percent_this_layer = (pruned_this_time * 100) // pruned_weights.size
             v.logger.debug("Pruned {} edges from layer {} ({}%)".format(pruned_this_time, i, percent_this_layer))
         total_edges = AnalyzeModel.total_edges(model)
         percent = (pruned_edges * 100) // total_edges

--- a/trainer.py
+++ b/trainer.py
@@ -5,6 +5,7 @@ from keras.models import Model
 from keras.applications import VGG16, VGG19
 import numpy as np
 import math
+from kardashigans.analyze_model import AnalyzeModel
 from kardashigans.verbose import Verbose
 
 
@@ -122,17 +123,24 @@ class BaseTrainer(Verbose):
     def prune_trained_model(model, threshold):
         if math.isnan(threshold):
             return
+        v = Verbose()
         # Layer 0 has no input edges, start from layer 1
         pruned_edges = 0
         for i in range(1, len(model.layers)):
             weights = model.layers[i].get_weights()
             input_weights = weights[0]  # weights[1] is the list of node biases
+            weighted_threshold = threshold * np.linalg.norm(input_weights)
             # The incoming edge weights of node N is incoming_edge_weights[N]
-            new_weights = np.where((input_weights < threshold) & (input_weights > -threshold), 0, input_weights)
-            pruned_edges += new_weights.size - np.count_nonzero(new_weights)
+            new_weights = np.where(np.absolute(input_weights) < weighted_threshold, 0, input_weights)
             model.layers[i].set_weights([np.array(new_weights), weights[1]])
-        v = Verbose()
-        v.logger.debug("Pruned {} edges (with threshold {})".format(pruned_edges, threshold))
+            pruned_this_time = new_weights.size - np.count_nonzero(new_weights)
+            pruned_edges += pruned_this_time
+            percent_this_layer = (pruned_this_time * 100) // new_weights.size
+            v.logger.debug("Pruned {} edges from layer {} ({}%)".format(pruned_this_time, i, percent_this_layer))
+        total_edges = AnalyzeModel.total_edges(model)
+        percent = (pruned_edges * 100) // total_edges
+        v.logger.debug("Pruned a total of {}/{} edges ({}%) (with threshold {})"
+                       "".format(pruned_edges, total_edges, percent, threshold))
 
     def _post_train(self, model):
         """ Inheriting classes C should call this method in the overridden _post_train """

--- a/winnery_intersection.py
+++ b/winnery_intersection.py
@@ -13,7 +13,7 @@ class WinneryIntersection(ExperimentWithCheckpoints):
     of some trained model, and the number of non-zero weights in layer i of
     the winnery lotter ticket.
     """
-    def __init__(self, prune_threshold, *args, **kwargs):
+    def __init__(self, prune_threshold=0.001, *args, **kwargs):
         assert not math.isnan(prune_threshold) and prune_threshold >= 0, \
             "Must init WinneryIntersection with non-negative float value for pruning threshold"
         self._prune_threshold = prune_threshold


### PR DESCRIPTION
Solves #91 

This PR also improves debug logging of pruning process (outputs % of edges pruned) so I also added a default value for `threshold` in `WinneryExperiment` (0.001).

Can either of you make sense of the results...? Percent of edges pruned is 1 minus winnery intersection ratio (which is what it should be, right?)

![image](https://user-images.githubusercontent.com/3027929/62976237-d7322a80-be24-11e9-9978-3f2b7e3d5ae0.png)

