### PR TITLE
Accepted by me. For some reason unaccepted papers are authorless

### DIFF
--- a/latex/main.tex
+++ b/latex/main.tex
@@ -17,7 +17,7 @@
 \newcommand{\theHalgorithm}{\arabic{algorithm}}
 
 % Use the following line for the initial blind version submitted for review:
-\usepackage{icml2019}
+\usepackage[accepted]{icml2019}
 
 % If accepted, instead use the following line for the camera-ready submission:
 %\usepackage[accepted]{icml2019}


### PR DESCRIPTION
Looking at icml2019.sty line 86, if the `accepted` option is passed to
the package then the `isaccepted` global command is defined. This is
checked in line 448 - unaccepted papers remain anonymous for some reason

Fixes #100 

Signed-off-by: dorimedini <dorimedini@gmail.com>