### PR TITLE
Now correctly parse input layers_to_freeze

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -332,7 +332,9 @@ class FCFreezeTrainer(FCTrainer):
         """
         super().__init__(**kwargs)
         weighted_layers = self.get_weighted_layers_indices()
-        self._layers_to_freeze = [weighted_layers[i] for i in layers_to_freeze] if layers_to_freeze else []
+        assert set(layers_to_freeze) <= set(weighted_layers), \
+            "Input layers_to_freeze list must be contained in {}".format(weighted_layers)
+        self._layers_to_freeze = layers_to_freeze if layers_to_freeze else []
         self._weight_map = weight_map if weight_map else {}
         if layers_to_copy and weight_map:
             layers_to_copy = [weighted_layers[i] for i in layers_to_copy]

--- a/trainer.py
+++ b/trainer.py
@@ -337,7 +337,8 @@ class FCFreezeTrainer(FCTrainer):
         self._layers_to_freeze = layers_to_freeze if layers_to_freeze else []
         self._weight_map = weight_map if weight_map else {}
         if layers_to_copy and weight_map:
-            layers_to_copy = [weighted_layers[i] for i in layers_to_copy]
+            assert set(layers_to_copy) <= set(weighted_layers), \
+                "Input layers_to_copy list must be contained in {}".format(weighted_layers)
             self._weight_map = {idx: weight_map[idx] for idx in layers_to_copy}
 
     def _train(self):


### PR DESCRIPTION
Previously if layers_to_freeze=[1,2,3] and get_weighted_layers_indices()
returns [1,2,3], then the init would fail on index OOB error: for i=3 in
layers_to_freeze, get_weighted_layers_indices()[3] doesn't exist.

Signed-off-by: dorimedini <dorimedini@gmail.com>